### PR TITLE
Chocolatey.org now only accepts TLS 1.2 connections. Hence, this change

### DIFF
--- a/shell/InstallChocolatey.ps1
+++ b/shell/InstallChocolatey.ps1
@@ -10,6 +10,7 @@ $env:ChocolateyInstall = "$($env:SystemDrive)\ProgramData\Chocolatey"
 $env:Path += ";$ChocoInstallPath"
 $DebugPreference = "Continue";
 $env:ChocolateyEnvironmentDebug = 'true'
+[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
 
 function Install-LocalChocolateyPackage {
 param (


### PR DESCRIPTION
This change is to ensure that the installation of Chocolatey happens using TLs 1.2
Without this change, the installation of Chocolatey fails and the entire
setup of the Vagrant box fails as well.